### PR TITLE
Enable dependabot for git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: "daily"
+    time: '08:00'
+    timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: "daily"
+    time: '08:00'
+    timezone: Asia/Tokyo
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- wow [Configuration options for the dependabot.yml file - GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)