### PR TITLE
Grouping Dependabot's dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,16 @@ updates:
       time: '08:00'
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    groups:
+      iterm2-plugins:
+        patterns:
+          - ".config/iterm2/*"
+      tmux-plugins:
+        patterns:
+          - ".config/tmux/plugins/*"
+      zsh-plugins:
+        patterns:
+          - ".config/zsh/*"
+      vim-plugins:
+        patterns:
+          - ".vim/pack/*"


### PR DESCRIPTION
- [Customizing dependency updates - GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request)