### PR TITLE
Remove dotenv and untap font (deprecated)

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -1,7 +1,6 @@
 brew "bat"
 brew "curl"
 brew "direnv"
-brew "dotenv"
 brew "editorconfig"
 brew "gh"
 brew "gibo"
@@ -43,8 +42,6 @@ cask "jordanbaird-ice"
 cask "keybase"
 cask "obsidian"
 cask "visual-studio-code"
-
-tap "homebrew/cask-fonts"
 cask "font-meslo-lg-nerd-font"
 
 tap "homebrew/autoupdate"


### PR DESCRIPTION
- [Homebrew/homebrew-cask-fonts: 💀 Casks of Ｆ🅾𝓝𝐓𝚂 (deprecated)](https://github.com/Homebrew/homebrew-cask-fonts)

  > These have mostly been migrated to [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask)